### PR TITLE
#41 RSpecのバグを修正

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -1,0 +1,15 @@
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'bin/*'
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'bin/*'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'bin/*'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'bin/*'

--- a/api/bin/rails
+++ b/api/bin/rails
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'


### PR DESCRIPTION
# 要件&設計
なし

# 何を?(What)
Railsの設定

# 何の為に?(Why)
RSpecのバグを修正

# どうやって?(How)
-`bin/rails`から `# frozen_string_literal: true`を削除
- .rubocop.ymに`bin/*`を検出の対象に含めないことを記述

# 確認事項
- [x] `bundle exec rspec`を実行してエラーが発生しない。
